### PR TITLE
Update precommit and customize linter rules

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
@@ -45,6 +45,11 @@ repos:
       {%- endif %}
       - id: trailing-whitespace
         types: [python]
+  - repo: https://github.com/python-poetry/poetry
+    rev: '1.6.0'
+    hooks:
+      - id: poetry-check
+      - id: poetry-lock
   - repo: local
     hooks:
       {%- if cookiecutter.with_conventional_commits|int %}
@@ -76,21 +81,9 @@ repos:
         args: [--check-sourced]
         language: system
         types: [shell]
-      {%- endif %}
-      - id: poetry-check
-        name: poetry check
-        entry: poetry check
-        language: system
-        files: pyproject.toml
-        pass_filenames: false
-      - id: poetry-lock-check
-        name: poetry lock check
-        entry: poetry lock
-        args: [--check]
-        language: system
-        pass_filenames: false
       - id: mypy
         name: mypy
         entry: mypy
         language: system
         types: [python]
+      {%- endif %}

--- a/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
@@ -151,11 +151,11 @@ ignore-init-module-imports = true
 line-length = 99
 {%- if cookiecutter.development_environment == "strict" %}
 select = ["A", "ASYNC", "B", "BLE", "C4", "C90", "D", "DTZ", "E", "EM", "ERA", "F", "FLY", "G", "I", "ICN", "INP", "ISC", "N", "NPY", "PGH", "PIE", "PLC", "PLE", "PLR", "PLW", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "S", "SIM", "SLF", "T10", "T20", "TCH", "TID", "TRY", "UP", "W", "YTT"]
-ignore = ["E501", "PGH001", "RET504", "S101"]
+ignore = ["E501", "PGH001", "RET504", "S101", "W505", "PTH123"]
 unfixable = ["ERA001", "F401", "F841", "T201", "T203"]
 {%- else %}
 select = ["A", "ASYNC", "B", "C4", "C90", "D", "DTZ", "E", "F", "FLY", "I", "ISC", "N", "NPY", "PGH", "PIE", "PLC", "PLE", "PLR", "PLW", "PT", "RET", "RUF", "RSE", "SIM", "TID", "UP", "W", "YTT"]
-ignore = ["E501", "PGH001", "PGH002", "PGH003", "RET504", "S101"]
+ignore = ["E501", "PGH001", "PGH002", "PGH003", "RET504", "S101", "W505", "PTH123"]
 unfixable = ["F401", "F841"]
 {%- endif %}
 src = ["src", "tests"]

--- a/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
@@ -78,6 +78,8 @@ typeguard = ">=3.0.2"
 
 [tool.poetry.group.dev.dependencies]  # https://python-poetry.org/docs/master/managing-dependencies/
 cruft = ">=2.14.0"
+ipython = ">=8.14.0"
+ipykernel = ">=6.25.1"
 {%- if cookiecutter.with_jupyter_lab|int %}
 jupyterlab = ">=3.6.3"
 {%- endif %}


### PR DESCRIPTION
Changed deprecated poetry hooks in pre-commit and ignored rules W505 (docstring too long) and PTH123 (use pathlib to open files).