### PR TITLE
Various update to cookiecutter

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
@@ -40,9 +40,6 @@ repos:
       - id: mixed-line-ending
       - id: name-tests-test
         args: [--pytest-test-first]
-      {%- if cookiecutter.development_environment == "strict" %}
-      - id: no-commit-to-branch
-      {%- endif %}
       - id: trailing-whitespace
         types: [python]
   - repo: https://github.com/python-poetry/poetry

--- a/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/.pre-commit-config.yaml
@@ -84,3 +84,4 @@ repos:
         language: system
         types: [python]
       {%- endif %}
+exclude: 'tests/tests_data/.*'

--- a/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
@@ -32,6 +32,7 @@ gunicorn = ">=20.1.0"
 {%- endif %}
 {%- if cookiecutter.with_fastapi_api|int or cookiecutter.with_streamlit_app|int %}
 poethepoet = ">=0.20.0"
+python-decouple = "^3.8"
 {%- endif %}
 {%- if cookiecutter.with_pydantic_typing|int %}
 pydantic = ">=1.10.7"

--- a/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__package_name_kebab_case }}/pyproject.toml
@@ -152,11 +152,11 @@ ignore-init-module-imports = true
 line-length = 99
 {%- if cookiecutter.development_environment == "strict" %}
 select = ["A", "ASYNC", "B", "BLE", "C4", "C90", "D", "DTZ", "E", "EM", "ERA", "F", "FLY", "G", "I", "ICN", "INP", "ISC", "N", "NPY", "PGH", "PIE", "PLC", "PLE", "PLR", "PLW", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "S", "SIM", "SLF", "T10", "T20", "TCH", "TID", "TRY", "UP", "W", "YTT"]
-ignore = ["E501", "PGH001", "RET504", "S101", "W505", "PTH123"]
+ignore = ["E501", "PGH001", "RET504", "S101", "W505", "PTH123", "E731"]
 unfixable = ["ERA001", "F401", "F841", "T201", "T203"]
 {%- else %}
 select = ["A", "ASYNC", "B", "C4", "C90", "D", "DTZ", "E", "F", "FLY", "I", "ISC", "N", "NPY", "PGH", "PIE", "PLC", "PLE", "PLR", "PLW", "PT", "RET", "RUF", "RSE", "SIM", "TID", "UP", "W", "YTT"]
-ignore = ["E501", "PGH001", "PGH002", "PGH003", "RET504", "S101", "W505", "PTH123"]
+ignore = ["E501", "PGH001", "PGH002", "PGH003", "RET504", "S101", "W505", "PTH123", "E731"]
 unfixable = ["F401", "F841"]
 {%- endif %}
 src = ["src", "tests"]


### PR DESCRIPTION
- [Remove hook no-commit-to-branch](https://github.com/Baseline-quebec/baseline-app-cookiecutter/commit/bc61751b12c34b0ef239a71cebb48585d6d956e4) 
  Remove hook no-commit-to-branch so that Github Actions don't fail after merge on main. Is kind of useless anyway since we can block merges into main at the Github level.

- [Exclude pre-commit checks on fake data used to test functions](https://github.com/Baseline-quebec/baseline-app-cookiecutter/commit/1ef1097ddaf4f41df59651454a5710c18eaf6364)

- [Add python-decouple package when env var are likely to be used](https://github.com/Baseline-quebec/baseline-app-cookiecutter/commit/cbacc1d9f40ed8ad98b38e4c4860b7383a9ee338)

- [Add ignore ruff rule](https://github.com/Baseline-quebec/baseline-app-cookiecutter/commit/c78acecfb365289a04693f007ea3d4bfa6f4dabc) 
  Ignore ruff rule to not used named lambda. Rationale: Naming named lambda is better if it increases readability instead of using comments. Example:
  ```
  [x for x in data if x["isbn"]]  # It's a book if it has an ISBN
  ```
  versus
  ```
  is_book = lambda doc: doc["isbn"]
  [x for x in data if is_book(x)]
  ```
  versus
  ```
  def is_book(doc: Document) -> Any:
      """This is a useless docstring."""
      return doc["isbn"]
  [x for x in data if is_book(x)]
  ```