### PR TITLE
feat: add .mcp-profile with interactive server selection

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -17,6 +17,7 @@
   "with_typer_cli": "1",
   "with_pytest_bdd": "0",
   "with_sentry": "0",
+  "mcp_profile": ["dev", "support", "automation"],
   "__docker_image": "python:$PYTHON_VERSION-slim",
   "__docstring_style": "Google",
   "__project_name_kebab_case": "{{ cookiecutter.project_name|slugify }}",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -2,11 +2,13 @@
 
 import os
 import shutil
+from pathlib import Path
 
 # Read Cookiecutter configuration.
 project_name = "{{ cookiecutter.__project_name_snake_case }}"
 development_environment = "{{ cookiecutter.development_environment }}"
 with_conventional_commits = int("{{ cookiecutter.with_conventional_commits }}")
+mcp_profile = "{{ cookiecutter.mcp_profile }}"
 with_fastapi_api = int("{{ cookiecutter.with_fastapi_api }}")
 with_typer_cli = int("{{ cookiecutter.with_typer_cli }}")
 with_pytest_bdd = int("{{ cookiecutter.with_pytest_bdd }}")
@@ -48,3 +50,56 @@ if not with_pytest_bdd:
 # Remove LICENSE file for proprietary projects.
 if license_choice == "Proprietary":
     os.remove("LICENSE")
+
+# ── MCP Profile: interactive server selection ───────────────────
+BASELINE_DIR = Path.home() / ".baseline"
+CONFIG_DIR = BASELINE_DIR / "mcp-config"
+REGISTRY_PATH = CONFIG_DIR / "registry.yaml"
+PROFILE_PATH = CONFIG_DIR / "profiles" / f"{mcp_profile}.yaml"
+
+if REGISTRY_PATH.exists() and PROFILE_PATH.exists():
+    try:
+        import yaml
+
+        with open(REGISTRY_PATH) as f:
+            registry = yaml.safe_load(f)
+        with open(PROFILE_PATH) as f:
+            profile = yaml.safe_load(f)
+
+        servers = profile["servers"]
+        print(f"\n  Serveurs MCP du profil '{mcp_profile}':")
+        for i, name in enumerate(servers, 1):
+            server = registry["servers"].get(name, {})
+            server_type = server.get("type", "?")
+            print(f"    {i}. {name} ({server_type})")
+
+        print(f"\n  Modifier la selection? (Enter pour accepter, ou +serveur/-serveur)")
+        user_input = input("  > ").strip()
+
+        if user_input:
+            selected = set(servers)
+            for token in user_input.split():
+                if token.startswith("-"):
+                    selected.discard(token[1:])
+                elif token.startswith("+"):
+                    server_name = token[1:]
+                    if server_name in registry["servers"]:
+                        selected.add(server_name)
+                    else:
+                        print(f"    ⚠ '{server_name}' n'existe pas dans le registry")
+
+            # Write extended format with selected servers
+            with open(".mcp-profile", "w") as f:
+                f.write(f"profile: {mcp_profile}\nservers:\n")
+                for s in selected:
+                    f.write(f"  - {s}\n")
+            print(f"  ✓ .mcp-profile ecrit ({len(selected)} serveurs)")
+        else:
+            print(f"  ✓ .mcp-profile ecrit (profil complet, {len(servers)} serveurs)")
+
+    except ImportError:
+        print("  ⚠ PyYAML non disponible — .mcp-profile ecrit avec le profil complet")
+    except Exception as e:
+        print(f"  ⚠ Erreur MCP: {e} — .mcp-profile ecrit avec le profil complet")
+else:
+    print(f"  ℹ mcp-config non installe — .mcp-profile ecrit avec le profil '{mcp_profile}'")

--- a/{{ cookiecutter.__project_name_kebab_case }}/.gitignore
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.gitignore
@@ -62,6 +62,7 @@ __pycache__/
 
 # Claude Code
 .claude/settings.local.json
+.mcp.json
 
 # VS Code
 .vscode/*

--- a/{{ cookiecutter.__project_name_kebab_case }}/.mcp-profile
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.mcp-profile
@@ -1,0 +1,1 @@
+{{ cookiecutter.mcp_profile }}


### PR DESCRIPTION
## Summary
- New `mcp_profile` variable in cookiecutter.json (dev/support/automation)
- Post-gen hook reads the registry and shows available servers
- User can customize with `+server/-server` syntax
- `.mcp.json` added to `.gitignore` template
- `.mcp-profile` committed in generated project

🤖 Generated with [Claude Code](https://claude.com/claude-code)