### PR TITLE
build: migrate from Poetry to uv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ notebooks/
 # Node.js
 node_modules/
 
-# Poetry
+# uv
 .venv/
 dist/
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A modern [Cookiecutter](https://github.com/cookiecutter/cookiecutter) template f
 
 - Quick and reproducible development environments with VS Code's [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers), PyCharm's [Docker Compose interpreter](https://www.jetbrains.com/help/pycharm/using-docker-compose-as-a-remote-interpreter.html#docker-compose-remote), and [GitHub Codespaces](https://github.com/features/codespaces)
 - Cross-platform support for Linux, macOS (Apple silicon and Intel), and Windows
-- Packaging and dependency management with [Poetry](https://github.com/python-poetry/poetry)
+- Packaging and dependency management with [uv](https://github.com/astral-sh/uv)
 - Task running with [Poe the Poet](https://github.com/nat-n/poethepoet)
 - Code formatting and linting with [Ruff](https://github.com/charliermarsh/ruff), [Mypy](https://github.com/python/mypy), and [Pre-commit](https://pre-commit.com/)
 - Spell checking with [codespell](https://github.com/codespell-project/codespell)
@@ -99,7 +99,7 @@ baseline-app-cookiecutter/
 │   ├── .github/workflows/             # CI + LLM scan for generated projects
 │   ├── src/{{ ... }}/                 # Source code stubs
 │   ├── tests/                         # Test stubs
-│   ├── pyproject.toml                 # Poetry config
+│   ├── pyproject.toml                 # project config (uv)
 │   └── ...
 ├── .github/
 │   ├── workflows/ci.yml               # Unit tests
@@ -112,9 +112,9 @@ baseline-app-cookiecutter/
 
 ## Upstream sync
 
-This template is a fork of [superlinear-ai/substrate](https://github.com/superlinear-ai/substrate). The upstream has since migrated to [uv](https://github.com/astral-sh/uv) (replacing Poetry), [Copier](https://copier.readthedocs.io/) (replacing Cookiecutter), and [ty](https://github.com/astral-sh/ty) (replacing Mypy). These are major structural changes that would require reworking the entire Baseline toolchain.
+This template is a fork of [superlinear-ai/substrate](https://github.com/superlinear-ai/substrate). The upstream has since migrated to [uv](https://github.com/astral-sh/uv) (replacing Poetry), [Copier](https://copier.readthedocs.io/) (replacing Cookiecutter), and [ty](https://github.com/astral-sh/ty) (replacing Mypy).
 
-We intentionally stay on **Poetry + Cookiecutter + Mypy** to maintain compatibility with existing Baseline projects. Instead of a full upstream merge, we cherry-pick individual improvements that are independent of the build system migration.
+We have adopted **uv** for packaging and dependency management, while intentionally staying on **Cookiecutter + Mypy** to maintain compatibility with existing Baseline projects. Instead of a full upstream merge, we cherry-pick individual improvements that are independent of the remaining migrations.
 
 ## Template parameters
 

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -828,3 +828,146 @@ class TestClaudeCodeConfig:
         assert "contremaitre" in content.lower()
         assert "context7" in content
         assert "playwright" in content
+
+
+# ---------------------------------------------------------------------------
+# uv migration (Poetry -> uv)
+# ---------------------------------------------------------------------------
+
+
+class TestUvMigration:
+    """Verify the project is a well-formed uv project, not a Poetry one."""
+
+    def test_build_backend_is_hatchling(self, output_dir: Path) -> None:
+        """Build backend is hatchling, not poetry-core."""
+        import tomllib
+
+        project = bake(output_dir)
+        parsed = tomllib.loads((project / "pyproject.toml").read_bytes().decode())
+        assert parsed["build-system"]["build-backend"] == "hatchling.build"
+        requires = " ".join(parsed["build-system"]["requires"])
+        assert "hatchling" in requires
+        assert "poetry" not in requires
+
+    def test_wheel_targets_src_package(self, output_dir: Path) -> None:
+        """Hatchling wheel target points at the src package."""
+        import tomllib
+
+        project = bake(output_dir)
+        parsed = tomllib.loads((project / "pyproject.toml").read_bytes().decode())
+        packages = parsed["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"]
+        assert packages == ["src/test_project"]
+
+    def test_no_tool_poetry_table(self, output_dir: Path) -> None:
+        """No [tool.poetry] table remains anywhere in pyproject.toml."""
+        import tomllib
+
+        project = bake(output_dir)
+        parsed = tomllib.loads((project / "pyproject.toml").read_bytes().decode())
+        assert "poetry" not in parsed["tool"]
+        assert "poetry" not in (project / "pyproject.toml").read_text().lower()
+
+    def test_dependency_groups_present(self, output_dir: Path) -> None:
+        """Dev/test dependencies live under [dependency-groups], not Poetry groups."""
+        import tomllib
+
+        project = bake(output_dir)
+        parsed = tomllib.loads((project / "pyproject.toml").read_bytes().decode())
+        groups = parsed["dependency-groups"]
+        assert "test" in groups
+        assert "dev" in groups
+        # test group holds real test deps
+        assert any(dep.startswith("pytest") for dep in groups["test"])
+        # dev group holds tooling
+        assert any(dep.startswith("mkdocs-material") for dep in groups["dev"])
+
+    def test_runtime_deps_use_pep508(self, output_dir: Path) -> None:
+        """Runtime dependencies are a PEP 508 list under [project], not a table."""
+        import tomllib
+
+        project = bake(output_dir, with_fastapi_api="1")
+        parsed = tomllib.loads((project / "pyproject.toml").read_bytes().decode())
+        deps = parsed["project"]["dependencies"]
+        assert isinstance(deps, list)
+        assert any(d.startswith("fastapi") for d in deps)
+        assert any(d.startswith("pydantic-settings") for d in deps)
+
+    def test_tool_uv_default_groups(self, output_dir: Path) -> None:
+        """uv installs the test and dev groups by default."""
+        import tomllib
+
+        project = bake(output_dir)
+        parsed = tomllib.loads((project / "pyproject.toml").read_bytes().decode())
+        assert parsed["tool"]["uv"]["default-groups"] == ["test", "dev"]
+
+    def test_poe_executor_is_simple(self, output_dir: Path) -> None:
+        """poe runs tasks in the active venv (simple), not via `uv run`.
+
+        Without this, poethepoet's auto executor triggers an implicit `uv sync`
+        that reinstalls the editable project into the baked devcontainer venv and
+        fails with a permission error, breaking `poe lint` / `poe test` in CI.
+        """
+        import tomllib
+
+        project = bake(output_dir)
+        parsed = tomllib.loads((project / "pyproject.toml").read_bytes().decode())
+        assert parsed["tool"]["poe"]["executor"]["type"] == "simple"
+
+    def test_commitizen_version_provider_pep621(self, output_dir: Path) -> None:
+        """Commitizen reads the version from PEP 621 metadata, not from Poetry."""
+        import tomllib
+
+        project = bake(output_dir, development_environment="strict")
+        parsed = tomllib.loads((project / "pyproject.toml").read_bytes().decode())
+        assert parsed["tool"]["commitizen"]["version_provider"] == "pep621"
+
+    def test_typer_script_entry_point(self, output_dir: Path) -> None:
+        """The CLI entry point is declared under [project.scripts]."""
+        import tomllib
+
+        project = bake(output_dir, with_typer_cli="1")
+        parsed = tomllib.loads((project / "pyproject.toml").read_bytes().decode())
+        assert parsed["project"]["scripts"]["test-project"] == "test_project.cli:app"
+
+    def test_pre_commit_checks_uv_lock(self, output_dir: Path) -> None:
+        """The pre-commit lock check uses uv, not `poetry check`."""
+        project = bake(output_dir)
+        content = (project / ".pre-commit-config.yaml").read_text()
+        assert "uv lock --check" in content
+        assert "poetry check" not in content
+
+    def test_dependabot_uses_uv_ecosystem(self, output_dir: Path) -> None:
+        """Dependabot tracks Python deps via the uv ecosystem, not pip."""
+        import yaml
+
+        project = bake(output_dir, development_environment="strict")
+        parsed = yaml.safe_load((project / ".github" / "dependabot.yml").read_text())
+        ecosystems = {u["package-ecosystem"] for u in parsed["updates"]}
+        assert "uv" in ecosystems
+        assert "pip" not in ecosystems
+
+    def test_ci_cache_key_uses_uv_lock(self, output_dir: Path) -> None:
+        """The CI Docker cache key hashes uv.lock, not poetry.lock."""
+        project = bake(output_dir)
+        content = (project / ".github" / "workflows" / "test.yml").read_text()
+        assert "uv.lock" in content
+        assert "poetry.lock" not in content
+
+    def test_dockerfile_installs_project_non_editable_free(self, output_dir: Path) -> None:
+        """Dockerfile syncs with uv and never references Poetry."""
+        project = bake(output_dir)
+        content = (project / "Dockerfile").read_text()
+        assert "uv sync" in content
+        assert "ghcr.io/astral-sh/uv" in content
+        assert "poetry" not in content.lower()
+
+    def test_settings_allow_uv_not_poetry(self, output_dir: Path) -> None:
+        """Claude Code settings allow uv commands and drop the Poetry allowance."""
+        import json
+
+        project = bake(output_dir)
+        allow = json.loads(
+            (project / ".claude" / "settings.json").read_text()
+        )["permissions"]["allow"]
+        assert "Bash(uv *)" in allow
+        assert "Bash(poetry *)" not in allow

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -283,11 +283,13 @@ class TestDockerfile:
         assert "AS dev" in from_lines[1]
         assert "AS app" in from_lines[2]
 
-    def test_poetry_version(self, output_dir: Path) -> None:
-        """Dockerfile uses Poetry 2.3.x."""
+    def test_uv_install(self, output_dir: Path) -> None:
+        """Dockerfile installs uv and uses `uv sync`."""
         project = bake(output_dir)
         content = (project / "Dockerfile").read_text()
-        assert "POETRY_VERSION=2.3." in content
+        assert "ghcr.io/astral-sh/uv" in content
+        assert "uv sync" in content
+        assert "poetry" not in content.lower()
 
     def test_healthcheck_with_fastapi(self, output_dir: Path) -> None:
         """Dockerfile has HEALTHCHECK when FastAPI is enabled."""
@@ -502,7 +504,11 @@ class TestCombinations:
         content = (project / "pyproject.toml").read_bytes()
         parsed = tomllib.loads(content.decode())
         assert "tool" in parsed
-        assert "poetry" in parsed["tool"]
+        assert "project" in parsed
+        assert parsed["project"]["name"] == "test-project"
+        assert parsed["build-system"]["build-backend"] == "hatchling.build"
+        assert "uv" in parsed["tool"]
+        assert "poetry" not in parsed["tool"]
 
 
 # ---------------------------------------------------------------------------
@@ -524,7 +530,7 @@ class TestCodespell:
         """codespell dependency is in test dependencies."""
         project = bake(output_dir)
         content = (project / "pyproject.toml").read_text()
-        assert 'codespell = ">=2.4.0"' in content
+        assert '"codespell>=2.4.0"' in content
 
     def test_codespell_config_in_pyproject(self, output_dir: Path) -> None:
         """codespell configuration section exists in pyproject.toml."""
@@ -794,7 +800,7 @@ class TestClaudeCodeConfig:
         content = json.loads((project / ".claude" / "settings.json").read_text())
         allow = content["permissions"]["allow"]
         deny = content["permissions"]["deny"]
-        assert "Bash(poetry *)" in allow
+        assert "Bash(uv *)" in allow
         assert "Bash(git *)" in allow
         assert "Bash(gh pr *)" in allow
         assert "Edit" in allow

--- a/{{ cookiecutter.__project_name_kebab_case }}/.claude/settings.json
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.claude/settings.json
@@ -45,7 +45,6 @@
       "Bash(echo *)",
       "Bash(* --version)",
       "Bash(* --help)",
-      "Bash(poetry *)",
       "Bash(npm *)",
       "Bash(npx *)",
       "Bash(pip *)",

--- a/{{ cookiecutter.__project_name_kebab_case }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}/",
     "remoteUser": "user",
     "overrideCommand": true,
-    "postStartCommand": "cp --update /opt/build/poetry/poetry.lock /workspaces/${localWorkspaceFolderBasename}/ && mkdir -p /workspaces/${localWorkspaceFolderBasename}/.git/hooks/ && cp --update /opt/build/git/* /workspaces/${localWorkspaceFolderBasename}/.git/hooks/",
+    "postStartCommand": "cp --update /opt/build/uv/uv.lock /workspaces/${localWorkspaceFolderBasename}/ && mkdir -p /workspaces/${localWorkspaceFolderBasename}/.git/hooks/ && cp --update /opt/build/git/* /workspaces/${localWorkspaceFolderBasename}/.git/hooks/",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/{{ cookiecutter.__project_name_kebab_case }}/.github/dependabot.yml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
         - "*"
         update-types:
         - "major"
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: monthly

--- a/{{ cookiecutter.__project_name_kebab_case }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: {% raw %}${{{% endraw %} runner.os }}-docker-{% raw %}${{{% endraw %} hashFiles('**/poetry.lock') }}
+          key: {% raw %}${{{% endraw %} runner.os }}-docker-{% raw %}${{{% endraw %} hashFiles('**/uv.lock') }}
           restore-keys: |
             {% raw %}${{{% endraw %} runner.os }}-docker-
 

--- a/{{ cookiecutter.__project_name_kebab_case }}/.gitignore
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.gitignore
@@ -37,7 +37,7 @@ notebooks/
 # Node.js
 node_modules/
 
-# Poetry
+# uv
 .venv/
 dist/
 

--- a/{{ cookiecutter.__project_name_kebab_case }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.pre-commit-config.yaml
@@ -95,10 +95,11 @@ repos:
         types: [shell]
         pass_filenames: false
       {%- endif %}
-      - id: poetry-check
-        name: poetry check
-        entry: poetry check
+      - id: uv-lock-check
+        name: uv lock check
+        entry: uv lock --check
         language: system
+        files: '^(pyproject\.toml|uv\.lock)$'
         pass_filenames: false
       - id: mypy
         name: mypy

--- a/{{ cookiecutter.__project_name_kebab_case }}/CLAUDE.md
+++ b/{{ cookiecutter.__project_name_kebab_case }}/CLAUDE.md
@@ -22,20 +22,20 @@ This project follows the [Baseline development conventions](https://github.com/B
 src/{{ cookiecutter.__project_name_snake_case }}/   # source code (src layout)
 tests/                                              # test suite
 docs/                                               # MkDocs documentation + ADRs
-pyproject.toml                                      # Poetry config, tool settings
+pyproject.toml                                      # project config (uv), tool settings
 ```
 
 ## Commands
 
-Always use `poetry run` — never `poetry shell`.
+Always use `uv run` to execute project commands so they run in the managed `.venv/`.
 
 ```bash
-poetry install                # install dependencies
-poetry run poe lint           # ruff + mypy + pre-commit
-poetry run poe test           # pytest with coverage
-poetry run poe docs --serve   # serve MkDocs locally
+uv sync                   # install dependencies
+uv run poe lint           # ruff + mypy + pre-commit
+uv run poe test           # pytest with coverage
+uv run poe docs --serve   # serve MkDocs locally
 {%- if cookiecutter.with_fastapi_api|int %}
-poetry run poe api --dev      # start FastAPI dev server
+uv run poe api --dev      # start FastAPI dev server
 {%- endif %}
 ```
 
@@ -48,7 +48,7 @@ poetry run poe api --dev      # start FastAPI dev server
 
 ## Tech stack
 
-- **Package manager**: [Poetry](https://python-poetry.org/)
+- **Package manager**: [uv](https://docs.astral.sh/uv/)
 - **Task runner**: [Poe the Poet](https://github.com/nat-n/poethepoet)
 - **Linting**: [Ruff](https://docs.astral.sh/ruff/) (linting + formatting)
 - **Type checking**: [Mypy](https://mypy.readthedocs.io/) (strict mode)

--- a/{{ cookiecutter.__project_name_kebab_case }}/CONTRIBUTING.md
+++ b/{{ cookiecutter.__project_name_kebab_case }}/CONTRIBUTING.md
@@ -19,8 +19,8 @@ poe api
 To install and use this project:
 
 ```sh
-poetry install
-poe test
+uv sync
+uv run poe test
 ```
 {%- endif %}
 
@@ -91,10 +91,10 @@ You can develop "remotely" inside a container using one of the following develop
 <summary>Local development</summary>
 
 To develop locally, you'll have to install manually some tools.
-First, initialize a virtual environment for the project with
-```poetry shell```
-and then install the dependencies and the project with
-```poetry install```
+Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then create the
+virtual environment and install the dependencies and the project in one step with
+```uv sync```
+uv automatically manages the `.venv/` for the project; prefix commands with `uv run` (e.g. `uv run poe test`).
 
 </details>
 
@@ -107,7 +107,7 @@ After setting up the development environment, you'll have to create an .env file
 
 ### Development tools
 
-The following tools will be automatically installed by poetry to support development:
+The following tools will be automatically installed by uv to support development:
 
 - _commitizen_: This project follows the [Conventional Commits](https://www.conventionalcommits.org/) standard to automate [Semantic Versioning](https://semver.org/) and [Keep A Changelog](https://keepachangelog.com/) with [Commitizen](https://github.com/commitizen-tools/commitizen).
 
@@ -159,9 +159,9 @@ We use the following integration tools:
 
 - Run `poe` from within the development environment to print a list of [Poe the Poet](https://github.com/nat-n/poethepoet) tasks available to run on this project.
 
-- Run `poetry add {package}` from within the development environment to install a run time dependency and add it to `pyproject.toml` and `poetry.lock`. Add `--group test` or `--group dev` to install a CI or development dependency, respectively.
+- Run `uv add {package}` from within the development environment to install a run time dependency and add it to `pyproject.toml` and `uv.lock`. Add `--group test` or `--group dev` to install a CI or development dependency, respectively.
 
-- Run `poetry update` from within the development environment to upgrade all dependencies to the latest versions allowed by `pyproject.toml`.
+- Run `uv lock --upgrade` from within the development environment to upgrade all dependencies to the latest versions allowed by `pyproject.toml`.
 
 - Run `cz bump` to bump the app's version, update the `CHANGELOG.md`, and create a git tag.
 

--- a/{{ cookiecutter.__project_name_kebab_case }}/Dockerfile
+++ b/{{ cookiecutter.__project_name_kebab_case }}/Dockerfile
@@ -2,6 +2,10 @@
 ARG PYTHON_VERSION={{ cookiecutter.python_version }}
 FROM {{ cookiecutter.__docker_image }} AS base
 
+# Install uv by copying its static binary from the official image [1].
+# [1] https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
 # Remove docker-clean so we can keep the apt cache in Docker build cache.
 RUN rm /etc/apt/apt.conf.d/docker-clean
 
@@ -11,13 +15,12 @@ RUN rm /etc/apt/apt.conf.d/docker-clean
 ENV PYTHONFAULTHANDLER=1
 ENV PYTHONUNBUFFERED=1
 
-# Install Poetry in a separate venv so it doesn't pollute the main venv.
-ENV POETRY_VERSION=2.3.2
-ENV POETRY_VIRTUAL_ENV=/opt/poetry-env
-RUN --mount=type=cache,target=/root/.cache/pip/ \
-    python -m venv $POETRY_VIRTUAL_ENV && \
-    $POETRY_VIRTUAL_ENV/bin/pip install poetry~=$POETRY_VERSION && \
-    ln -s $POETRY_VIRTUAL_ENV/bin/poetry /usr/local/bin/poetry
+# Configure uv: compile bytecode for faster startup, copy packages into the venv
+# (required when mounting the cache), and never download a managed Python [1].
+# [1] https://docs.astral.sh/uv/reference/environment/
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+ENV UV_PYTHON_DOWNLOADS=never
 
 # Install compilers that may be required for certain packages or platforms.
 RUN --mount=type=cache,target=/var/cache/apt/ \
@@ -37,17 +40,20 @@ USER user
 # Create and activate a virtual environment.
 ENV VIRTUAL_ENV=/opt/{{ cookiecutter.__project_name_kebab_case }}-env
 ENV PATH=$VIRTUAL_ENV/bin:$PATH
-RUN python -m venv $VIRTUAL_ENV
+ENV UV_PROJECT_ENVIRONMENT=$VIRTUAL_ENV
+RUN uv venv $VIRTUAL_ENV
 
 # Set the working directory.
 WORKDIR /workspaces/{{ cookiecutter.__project_name_kebab_case }}/
 
-# Install the run time Python dependencies in the virtual environment.
-COPY --chown=user:user poetry.lock* pyproject.toml /workspaces/{{ cookiecutter.__project_name_kebab_case }}/
-RUN mkdir -p /home/user/.cache/pypoetry/ && mkdir -p /home/user/.config/pypoetry/ && \
-    mkdir -p src/{{ cookiecutter.__project_name_snake_case }}/ && touch src/{{ cookiecutter.__project_name_snake_case }}/__init__.py && touch README.md
-RUN --mount=type=cache,uid=$UID,gid=$GID,target=/home/user/.cache/pypoetry/ \
-    poetry install --only main --all-extras --no-interaction
+# Install the run time Python dependencies in the virtual environment. The lock file is
+# optional here (a freshly scaffolded project has none): uv resolves and writes uv.lock
+# on the first build, which is then surfaced back to the workspace in the dev stage.
+COPY --chown=user:user pyproject.toml uv.lock* /workspaces/{{ cookiecutter.__project_name_kebab_case }}/
+RUN mkdir -p src/{{ cookiecutter.__project_name_snake_case }}/ && \
+    touch src/{{ cookiecutter.__project_name_snake_case }}/__init__.py && touch README.md
+RUN --mount=type=cache,uid=$UID,gid=$GID,target=/home/user/.cache/uv/ \
+    uv sync --no-default-groups
 
 
 
@@ -66,12 +72,12 @@ RUN --mount=type=cache,target=/var/cache/apt/ \
 USER user
 
 # Install the development Python dependencies in the virtual environment.
-RUN --mount=type=cache,uid=$UID,gid=$GID,target=/home/user/.cache/pypoetry/ \
-    poetry install --all-extras --no-interaction
+RUN --mount=type=cache,uid=$UID,gid=$GID,target=/home/user/.cache/uv/ \
+    uv sync
 
 # Persist output generated during docker build so that we can restore it in the dev container.
 COPY --chown=user:user .pre-commit-config.yaml /workspaces/{{ cookiecutter.__project_name_kebab_case }}/
-RUN mkdir -p /opt/build/poetry/ && cp poetry.lock /opt/build/poetry/ && \
+RUN mkdir -p /opt/build/uv/ && cp uv.lock /opt/build/uv/ && \
     git init && pre-commit install --install-hooks && \
     mkdir -p /opt/build/git/ && cp .git/hooks/commit-msg .git/hooks/pre-commit /opt/build/git/
 
@@ -96,8 +102,12 @@ FROM base AS app
 
 # Copy the {{ cookiecutter.project_type }} source code to the working directory.
 COPY --chown=user:user ./src ./src
-COPY --chown=user:user ./pyproject.toml .
-COPY --chown=user:user ./poetry.lock .
+COPY --chown=user:user ./pyproject.toml ./uv.lock ./
+
+# Install the {{ cookiecutter.project_type }} itself into the virtual environment. A committed
+# uv.lock is required to build this target so the runtime image is fully reproducible.
+RUN --mount=type=cache,uid=$UID,gid=$GID,target=/home/user/.cache/uv/ \
+    uv sync --no-default-groups --frozen
 {%- if cookiecutter.with_fastapi_api|int %}
 
 # Health check using stdlib only (no curl in slim images).

--- a/{{ cookiecutter.__project_name_kebab_case }}/README.md
+++ b/{{ cookiecutter.__project_name_kebab_case }}/README.md
@@ -22,10 +22,10 @@ cp .env.example .env
 Requirements:
 
 - [Python {{ cookiecutter.python_version }}](https://www.python.org/downloads/)
-- [Poetry](https://python-poetry.org/docs/#installation)
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 
 ```bash
-poetry install
+uv sync
 ```
 
 ### Container setup
@@ -55,10 +55,10 @@ Access the API at [localhost:8000](http://localhost:8000) and the docs at [local
 ### CLI
 
 ```bash
-poetry run {{ cookiecutter.__project_name_kebab_case }} info
-poetry run {{ cookiecutter.__project_name_kebab_case }} config
+uv run {{ cookiecutter.__project_name_kebab_case }} info
+uv run {{ cookiecutter.__project_name_kebab_case }} config
 {%- if cookiecutter.with_fastapi_api|int %}
-poetry run {{ cookiecutter.__project_name_kebab_case }} health
+uv run {{ cookiecutter.__project_name_kebab_case }} health
 {%- endif %}
 ```
 {%- endif %}
@@ -87,7 +87,7 @@ poe docs --serve  # serve documentation locally
 │   └── services.py                                    # business logic
 ├── tests/                                             # test suite
 ├── docs/                                              # MkDocs + ADRs
-├── pyproject.toml                                     # Poetry config
+├── pyproject.toml                                     # project config (uv)
 ├── Dockerfile                                         # production image
 └── docker-compose.yml                                 # local development
 ```

--- a/{{ cookiecutter.__project_name_kebab_case }}/docker-compose.yml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         UID: ${UID:-1000}
         GID: ${GID:-1000}
     environment:
-      - POETRY_PYPI_TOKEN_PYPI
+      - UV_PUBLISH_TOKEN
     volumes:
       - ..:/workspaces
       - command-history-volume:/home/user/.history/
@@ -23,7 +23,7 @@ services:
       [
         "sh",
         "-c",
-        "sudo chown user $$SSH_AUTH_SOCK && cp --update /opt/build/poetry/poetry.lock /workspaces/{{ cookiecutter.__project_name_kebab_case }}/ && mkdir -p /workspaces/{{ cookiecutter.__project_name_kebab_case }}/.git/hooks/ && cp --update /opt/build/git/* /workspaces/{{ cookiecutter.__project_name_kebab_case }}/.git/hooks/ && zsh"
+        "sudo chown user $$SSH_AUTH_SOCK && cp --update /opt/build/uv/uv.lock /workspaces/{{ cookiecutter.__project_name_kebab_case }}/ && mkdir -p /workspaces/{{ cookiecutter.__project_name_kebab_case }}/.git/hooks/ && cp --update /opt/build/git/* /workspaces/{{ cookiecutter.__project_name_kebab_case }}/.git/hooks/ && zsh"
       ]
     environment:
       - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock

--- a/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
@@ -1,81 +1,91 @@
-[build-system]  # https://python-poetry.org/docs/pyproject/#poetry-and-pep-517
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+[build-system]  # https://hatch.pypa.io/latest/config/build/
+requires = ["hatchling>=1.27.0"]
+build-backend = "hatchling.build"
 
-[tool.poetry]  # https://python-poetry.org/docs/pyproject/
+[project]  # https://packaging.python.org/en/latest/specifications/pyproject-toml/
 name = "{{ cookiecutter.__project_name_kebab_case }}"
 version = "0.0.0"
 description = "{{ cookiecutter.project_description }}"
-authors = ["{{ cookiecutter.author_name }} <{{ cookiecutter.author_email }}>"]
+authors = [{ name = "{{ cookiecutter.author_name }}", email = "{{ cookiecutter.author_email }}" }]
 readme = "README.md"
-repository = "{{ cookiecutter.project_url }}"
-license = "{{ cookiecutter.license }}"
+license = "{% if cookiecutter.license == 'Proprietary' %}LicenseRef-Proprietary{% else %}{{ cookiecutter.license }}{% endif %}"
+requires-python = ">={{ cookiecutter.python_version }},<4.0"
+dependencies = [
+{%- if cookiecutter.with_fastapi_api|int %}
+  "fastapi[all]>=0.115.0",
+  "loguru>=0.7.3",
+  "gunicorn>=23.0.0",
+{%- endif %}
+{%- if cookiecutter.project_type == "app" %}
+  "poethepoet>=0.32.0",
+{%- endif %}
+  "pydantic-settings>=2.7.0",
+{%- if cookiecutter.with_sentry|int %}
+  "sentry-sdk[fastapi]>=2.19.0",
+{%- endif %}
+{%- if cookiecutter.with_typer_cli|int %}
+  "typer>=0.15.0",
+{%- endif %}
+{%- if cookiecutter.with_fastapi_api|int %}
+  "uvicorn[standard]>=0.34.0",
+{%- endif %}
+]
+
+[project.urls]  # https://packaging.python.org/en/latest/specifications/well-known-project-urls/
+Repository = "{{ cookiecutter.project_url }}"
+{%- if cookiecutter.with_typer_cli|int %}
+
+[project.scripts]  # https://packaging.python.org/en/latest/specifications/pyproject-toml/#entry-points
+{{ cookiecutter.__project_name_kebab_case }} = "{{ cookiecutter.__project_name_snake_case }}.cli:app"
+{%- endif %}
 {%- if cookiecutter.with_conventional_commits|int %}
 
 [tool.commitizen]  # https://commitizen-tools.github.io/commitizen/config/
 bump_message = "bump(release): v$current_version → v$new_version"
 tag_format = "v$version"
 update_changelog_on_bump = true
-version_provider = "poetry"
-{%- endif %}
-{%- if cookiecutter.with_typer_cli|int %}
-
-[tool.poetry.scripts]  # https://python-poetry.org/docs/pyproject/#scripts
-{{ cookiecutter.__project_name_kebab_case }} = "{{ cookiecutter.__project_name_snake_case }}.cli:app"
+version_provider = "pep621"
 {%- endif %}
 
-[tool.poetry.dependencies]  # https://python-poetry.org/docs/dependency-specification/
-{%- if cookiecutter.with_fastapi_api|int %}
-fastapi = { extras = ["all"], version = ">=0.115.0" }
-loguru = ">=0.7.3"
-gunicorn = ">=23.0.0"
-{%- endif %}
-{%- if cookiecutter.project_type == "app" %}
-poethepoet = ">=0.32.0"
-{%- endif %}
-pydantic-settings = ">=2.7.0"
-python = ">={{ cookiecutter.python_version }},<4.0"
-{%- if cookiecutter.with_sentry|int %}
-sentry-sdk = { extras = ["fastapi"], version = ">=2.19.0" }
-{%- endif %}
-{%- if cookiecutter.with_typer_cli|int %}
-typer = { extras = ["all"], version = ">=0.15.0" }
-{%- endif %}
-{%- if cookiecutter.with_fastapi_api|int %}
-uvicorn = { extras = ["standard"], version = ">=0.34.0" }
-{%- endif %}
-
-[tool.poetry.group.test.dependencies]  # https://python-poetry.org/docs/master/managing-dependencies/
+[dependency-groups]  # https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-groups
+test = [
 {%- if cookiecutter.with_conventional_commits|int %}
-commitizen = ">=4.1.0"
+  "commitizen>=4.1.0",
 {%- endif %}
-coverage = { extras = ["toml"], version = ">=7.6.0" }
-detect-secrets = ">=1.5.0"
-mypy = ">=1.14.0"
-pre-commit = ">=4.0.0"
-pytest = ">=8.3.0"
+  "coverage[toml]>=7.6.0",
+  "detect-secrets>=1.5.0",
+  "mypy>=1.14.0",
+  "pre-commit>=4.0.0",
+  "pytest>=8.3.0",
 {%- if cookiecutter.with_pytest_bdd|int %}
-pytest-bdd = ">=8.1.0"
+  "pytest-bdd>=8.1.0",
 {%- endif %}
-pytest-mock = ">=3.14.0"
-pytest-xdist = ">=3.5.0"
+  "pytest-mock>=3.14.0",
+  "pytest-xdist>=3.5.0",
 {%- if cookiecutter.with_fastapi_api|int %}
-pytest-asyncio = ">=0.25.0"
+  "pytest-asyncio>=0.25.0",
 {%- endif %}
-httpx = ">=0.28.0"
-codespell = ">=2.4.0"
-ruff = ">=0.11.0"
+  "httpx>=0.28.0",
+  "codespell>=2.4.0",
+  "ruff>=0.11.0",
 {%- if cookiecutter.development_environment == "strict" %}
-safety = ">=3.2.0"
-shellcheck-py = ">=0.10.0.1"
-typeguard = ">=4.4.0"
+  "safety>=3.2.0",
+  "shellcheck-py>=0.10.0.1",
+  "typeguard>=4.4.0",
 {%- endif %}
+]
+dev = [
+  "cruft>=2.15.0",
+  "ipykernel>=6.29.4",
+  "ipywidgets>=8.1.2",
+  "mkdocs-material>=9.5.0",
+]
 
-[tool.poetry.group.dev.dependencies]  # https://python-poetry.org/docs/master/managing-dependencies/
-cruft = ">=2.15.0"
-ipykernel = ">=6.29.4"
-ipywidgets = ">=8.1.2"
-mkdocs-material = ">=9.5.0"
+[tool.uv]  # https://docs.astral.sh/uv/reference/settings/
+default-groups = ["test", "dev"]
+
+[tool.hatch.build.targets.wheel]  # https://hatch.pypa.io/latest/config/build/#build-targets
+packages = ["src/{{ cookiecutter.__project_name_snake_case }}"]
 
 [tool.coverage.report]  # https://coverage.readthedocs.io/en/latest/config.html#report
 {%- if cookiecutter.development_environment == "strict" %}
@@ -205,7 +215,7 @@ max-public-methods = 30
 builtin = "en-GB_to_en-US,clear,code,rare"
 check-filenames = true
 ignore-words-list = "jupyter"
-skip = "./*_cache/,./.venv,./reports"
+skip = "./*_cache/,./.venv,./reports,./uv.lock"
 
 [tool.poe.tasks]  # https://github.com/nat-n/poethepoet
 {%- if cookiecutter.with_fastapi_api|int %}

--- a/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
@@ -217,6 +217,12 @@ check-filenames = true
 ignore-words-list = "jupyter"
 skip = "./*_cache/,./.venv,./reports,./uv.lock"
 
+[tool.poe]  # https://poethepoet.natn.io/guides/uv_guide.html
+# Run tasks in the already-activated virtualenv instead of via `uv run`, which would
+# trigger an implicit `uv sync` that reinstalls the editable project into a read-only
+# baked venv (e.g. in the devcontainer / CI), failing with a permission error.
+executor.type = "simple"
+
 [tool.poe.tasks]  # https://github.com/nat-n/poethepoet
 {%- if cookiecutter.with_fastapi_api|int %}
 


### PR DESCRIPTION
## Résumé

Migre le cookiecutter de **Poetry** vers **uv** comme gestionnaire de paquets et de dépendances, autant pour les projets générés que pour l'outillage du template lui-même.

## Changements

- **pyproject.toml** : métadonnées PEP 621 `[project]`, backend de build `hatchling`, `[dependency-groups]` (`test`/`dev`), `[tool.uv]` `default-groups`, `commitizen.version_provider = pep621`. Retrait de l'extra `all` obsolète de `typer`.
- **Dockerfile** : installe `uv` depuis l'image officielle `ghcr.io/astral-sh/uv`, `uv venv` + `uv sync` sur les stages `base`/`dev`/`app`, `uv.lock` régénéré au build et resurfacé dans le workspace (même mécanisme que l'ancien `poetry.lock`).
- **docker-compose.yml / devcontainer.json** : `uv.lock` + `UV_PUBLISH_TOKEN`.
- **pre-commit** : hook `poetry check` remplacé par `uv lock --check`.
- **dependabot** : écosystème `pip` -> `uv`.
- **CI** : clé de cache `poetry.lock` -> `uv.lock`.
- **Docs** (README template + racine, CONTRIBUTING, CLAUDE.md) : commandes `uv sync` / `uv run` / `uv add` / `uv lock --upgrade` et mise à jour de la section « Upstream sync ».
- **Tests** : assertions sur uv/hatchling au lieu de Poetry.

## Validation

- 82/82 tests unitaires du template passent.
- Projet généré : `uv lock` (158 paquets, aucun avertissement), `uv sync`, build hatchling, import du paquet, entrypoint CLI (`[project.scripts]`) et `uv lock --check` OK.
- Build Docker non testé localement (daemon indisponible) ; le Dockerfile suit le pattern uv officiel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)