### PR TITLE
fix(ci): make integration workflow green (ruff preview drift + starlette + codespell)

### DIFF
--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -971,3 +971,86 @@ class TestUvMigration:
         )["permissions"]["allow"]
         assert "Bash(uv *)" in allow
         assert "Bash(poetry *)" not in allow
+
+
+# ---------------------------------------------------------------------------
+# Lint / CI configuration guards
+# ---------------------------------------------------------------------------
+
+
+class TestLintCiConfig:
+    """Guard the config that keeps a freshly scaffolded project's CI green.
+
+    These knobs were needed because ruff's preview rules and starlette 1.x
+    otherwise make `poe lint` / `poe test` fail on generated projects.
+    """
+
+    def test_strict_ignores_churning_preview_rules(self, output_dir: Path) -> None:
+        """Strict mode ignores the preview rules that conflict with our style."""
+        import tomllib
+
+        project = bake(output_dir, development_environment="strict")
+        ignore = tomllib.loads(
+            (project / "pyproject.toml").read_bytes().decode()
+        )["tool"]["ruff"]["lint"]["ignore"]
+        # RUF105: forces `# ruff: ignore` over `# noqa`. PLC0415: lazy imports.
+        # RUF201: rewrites rule codes to names in this very config.
+        for rule in ("RUF105", "PLC0415", "RUF201"):
+            assert rule in ignore
+
+    def test_simple_ignores_churning_preview_rules(self, output_dir: Path) -> None:
+        """Simple mode ignores the same preview rules plus RUF100 (unused noqa)."""
+        import tomllib
+
+        project = bake(output_dir, development_environment="simple")
+        ignore = tomllib.loads(
+            (project / "pyproject.toml").read_bytes().decode()
+        )["tool"]["ruff"]["lint"]["ignore"]
+        for rule in ("RUF105", "PLC0415", "RUF201", "RUF100"):
+            assert rule in ignore
+
+    def test_strict_fastapi_filters_starlette_warning(self, output_dir: Path) -> None:
+        """With FastAPI, strict pytest ignores starlette's httpx deprecation.
+
+        starlette 1.x raises StarletteDeprecationWarning (a UserWarning, so not
+        caught by `ignore::DeprecationWarning`); strict `filterwarnings=error`
+        would turn it into a collection error. There is no httpx2 to migrate to.
+        """
+        import tomllib
+
+        project = bake(output_dir, development_environment="strict", with_fastapi_api="1")
+        filters = tomllib.loads(
+            (project / "pyproject.toml").read_bytes().decode()
+        )["tool"]["pytest"]["ini_options"]["filterwarnings"]
+        assert any("StarletteDeprecationWarning" in f for f in filters)
+
+    def test_no_starlette_filter_without_fastapi(self, output_dir: Path) -> None:
+        """Without FastAPI, starlette is not installed, so do not reference it.
+
+        Referencing an uninstalled warning class in filterwarnings would make
+        pytest error out at startup.
+        """
+        import tomllib
+
+        project = bake(output_dir, development_environment="strict", with_fastapi_api="0")
+        filters = tomllib.loads(
+            (project / "pyproject.toml").read_bytes().decode()
+        )["tool"]["pytest"]["ini_options"]["filterwarnings"]
+        assert not any("starlette" in f for f in filters)
+
+    def test_codespell_ignores_french_terms(self, output_dir: Path) -> None:
+        """codespell tolerates the French terms in CLAUDE.md's Agents IA section."""
+        import tomllib
+
+        project = bake(output_dir)
+        words = tomllib.loads(
+            (project / "pyproject.toml").read_bytes().decode()
+        )["tool"]["codespell"]["ignore-words-list"]
+        for term in ("projet", "architecte", "librairies"):
+            assert term in words
+
+    def test_stub_api_has_no_trailing_whitespace(self, output_dir: Path) -> None:
+        """The FastAPI stub is free of trailing whitespace (ruff format / W291)."""
+        project = bake(output_dir, with_fastapi_api="1")
+        for line in (project / "src" / "test_project" / "api.py").read_text().splitlines():
+            assert line == line.rstrip(), f"trailing whitespace: {line!r}"

--- a/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
@@ -143,7 +143,7 @@ warn_untyped_fields = true
 # Development mode: {{ cookiecutter.development_environment }}
 {%- if cookiecutter.development_environment == "strict" %}
 addopts = "--color=yes --doctest-modules --exitfirst --failed-first --strict-config --strict-markers --typeguard-packages={{ cookiecutter.__project_name_snake_case }} --verbosity=2 --junitxml=reports/pytest.xml"
-filterwarnings = ["error", "ignore::DeprecationWarning", "ignore::pytest.PytestUnraisableExceptionWarning"]
+filterwarnings = ["error", "ignore::DeprecationWarning", "ignore::pytest.PytestUnraisableExceptionWarning"{% if cookiecutter.with_fastapi_api|int %}, "ignore::starlette.exceptions.StarletteDeprecationWarning"{% endif %}]
 {%- else %}
 addopts = "--color=yes --doctest-modules --exitfirst --failed-first --verbosity=2 --junitxml=reports/pytest.xml"
 {%- endif %}
@@ -181,11 +181,15 @@ ignore = [
     "ISC001", # single-line-implicit-string-concatenation, `z = "The quick " "brown fox."` becomes `z = "The quick brown fox."` This rule may cause conflicts when used with the formatter.
     "DOC201", # `return` is not documented in docstring. Too verbose for most projects.
     "DOC501", # Raised exception missing from docstring. Too verbose for most projects.
+    "PLC0415", # `import` should be at top-level. Lazy / conditional imports (e.g. optional Sentry) are intentional.
+    "RUF105", # noqa-comments (preview). We suppress with `# noqa`; do not force the `# ruff: ignore` syntax.
 ]
 unfixable = ["ERA001", "F401", "F841", "T201", "T203"]
 {%- else %}
 select = ["A", "ASYNC", "B", "C4", "C90", "D", "DTZ", "E", "F", "FLY", "I", "ISC", "LOG", "N", "NPY", "PERF", "PGH", "PIE", "PL", "PT", "Q", "RET", "RUF", "RSE", "SIM", "TID", "UP", "W", "YTT"]
-ignore = ["D203", "D213", "E501", "PGH003", "RET504"]
+# PLC0415: intentional lazy/conditional imports. RUF105 (preview): we suppress with `# noqa`.
+# RUF100: the stub `# noqa` comments target strict mode's fuller ruleset (ARG/FBT/S), unused here.
+ignore = ["D203", "D213", "E501", "PGH003", "PLC0415", "RET504", "RUF100", "RUF105"]
 unfixable = ["F401", "F841"]
 {%- endif %}
 
@@ -214,7 +218,7 @@ max-public-methods = 30
 [tool.codespell]  # https://github.com/codespell-project/codespell
 builtin = "en-GB_to_en-US,clear,code,rare"
 check-filenames = true
-ignore-words-list = "jupyter"
+ignore-words-list = "architecte,jupyter,librairies,projet"  # French terms in CLAUDE.md (bilingual docs)
 skip = "./*_cache/,./.venv,./reports,./uv.lock"
 
 [tool.poe]  # https://poethepoet.natn.io/guides/uv_guide.html

--- a/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
@@ -183,13 +183,15 @@ ignore = [
     "DOC501", # Raised exception missing from docstring. Too verbose for most projects.
     "PLC0415", # `import` should be at top-level. Lazy / conditional imports (e.g. optional Sentry) are intentional.
     "RUF105", # noqa-comments (preview). We suppress with `# noqa`; do not force the `# ruff: ignore` syntax.
+    "RUF201", # rule-codes-in-selectors (preview). This config references rules by code (with comments), on purpose.
 ]
 unfixable = ["ERA001", "F401", "F841", "T201", "T203"]
 {%- else %}
 select = ["A", "ASYNC", "B", "C4", "C90", "D", "DTZ", "E", "F", "FLY", "I", "ISC", "LOG", "N", "NPY", "PERF", "PGH", "PIE", "PL", "PT", "Q", "RET", "RUF", "RSE", "SIM", "TID", "UP", "W", "YTT"]
 # PLC0415: intentional lazy/conditional imports. RUF105 (preview): we suppress with `# noqa`.
-# RUF100: the stub `# noqa` comments target strict mode's fuller ruleset (ARG/FBT/S), unused here.
-ignore = ["D203", "D213", "E501", "PGH003", "PLC0415", "RET504", "RUF100", "RUF105"]
+# RUF100: stub `# noqa` comments target strict's fuller ruleset (ARG/FBT/S), unused here.
+# RUF201 (preview): this config references rules by code (with comments), on purpose.
+ignore = ["D203", "D213", "E501", "PGH003", "PLC0415", "RET504", "RUF100", "RUF105", "RUF201"]
 unfixable = ["F401", "F841"]
 {%- endif %}
 

--- a/{{ cookiecutter.__project_name_kebab_case }}/src/{{ cookiecutter.__project_name_snake_case }}/api.py
+++ b/{{ cookiecutter.__project_name_kebab_case }}/src/{{ cookiecutter.__project_name_snake_case }}/api.py
@@ -18,14 +18,15 @@ from {{ cookiecutter.__project_name_snake_case }}.settings import settings
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncGenerator[None]:  # noqa: ARG001, RUF029
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:  # noqa: ARG001
     """Handle FastAPI startup and shutdown events."""
     logger.remove()
     logger.add(sys.stderr, level=settings.log_level)
 {%- if cookiecutter.with_sentry|int %}
 
     if settings.sentry_dsn:
-        import sentry_sdk  
+        import sentry_sdk
+
         sentry_sdk.init(
             dsn=settings.sentry_dsn,
             environment=settings.sentry_environment,


### PR DESCRIPTION
## Contexte

La CI **Integration** (`test.yml`) était rouge sur `main` : elle scaffolde un projet via cruft, puis lance `poe lint` et `poe test` dans un devcontainer. Deux étapes échouaient.

## Causes et correctifs

### 1. `poe lint` — ruff 0.15.22 (mode preview)
Le code stub et le `pyproject.toml` déclenchaient des règles ruff, dont plusieurs **preview instables** (qui dérivent à chaque release de ruff — d'où le rouge récurrent) :
- **RUF105** (`noqa-comments`) : veut `# ruff: ignore` au lieu de `# noqa` → ignorée (on utilise `# noqa` par convention).
- **PLC0415** (`import-outside-top-level`) : import lazy/optionnel (Sentry) intentionnel → ignorée.
- **RUF201** (`rule-codes-in-selectors`) : réécrit les codes de règles en noms **dans le pyproject lui-même** → ignorée (on référence par code avec commentaires, volontairement).
- Vrais défauts corrigés dans `api.py` : trailing whitespace, `RUF029` inutile dans un `# noqa`, ligne vide après l'import Sentry conditionnel (ruff format).
- Mode simple : `RUF100` ignorée aussi (les `# noqa` du stub ciblent le ruleset plus large du mode strict).

### 2. `poe test` — starlette 1.x
Le mode strict (`filterwarnings=["error"]`) transformait `StarletteDeprecationWarning` (« use httpx2 ») en erreur de collection. C'est un `UserWarning` (pas `DeprecationWarning`, donc non filtré) et **httpx2 n'existe pas sur PyPI**. Filtré en mode strict, uniquement quand FastAPI est activé (sinon starlette n'est pas installé).

### 3. `poe lint` — codespell
Flaggait les termes français (projet, architecte, librairies) de la section « Agents IA » de `CLAUDE.md` → ajoutés à `ignore-words-list` (docs bilingues).

## Validation

Reproduction fidèle des **deux variants de la matrice CI** (cruft, py3.12 full + py3.13 minimal) : `poe lint` et `poe test` sortent tous les deux en **exit 0**. 102 tests unitaires du template passent (dont `TestLintCiConfig` qui verrouille ces réglages).

> **Note de durabilité** : la cause profonde du rouge récurrent est `preview = true` + `ruff` non épinglé (les règles preview changent à chaque release). Ces ignores traitent les règles actuelles ; une future release pourrait en introduire d'autres. Le fix durable serait d'épingler `ruff` (cohérent avec la politique de pinning Baseline) ou de passer `preview = false`. Dis-moi si tu veux que je le fasse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)