### PR TITLE
chore: retirer les serveurs MCP voice, context7 et bigquery

### DIFF
--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -741,15 +741,6 @@ class TestClaudeCodeConfig:
         project = bake(output_dir)
         assert (project / ".mcp.json").is_file()
 
-    def test_mcp_json_has_context7(self, output_dir: Path) -> None:
-        """.mcp.json contains context7 server."""
-        import json
-
-        project = bake(output_dir)
-        content = json.loads((project / ".mcp.json").read_text())
-        assert "context7" in content["mcpServers"]
-        assert content["mcpServers"]["context7"]["command"] == "npx"
-
     def test_mcp_json_has_playwright(self, output_dir: Path) -> None:
         """.mcp.json contains playwright server."""
         import json
@@ -772,7 +763,6 @@ class TestClaudeCodeConfig:
         content = json.loads(
             (project / ".claude" / "settings.local.json").read_text()
         )
-        assert "context7" in content["enabledMcpjsonServers"]
         assert "playwright" in content["enabledMcpjsonServers"]
 
     def test_gitignore_has_claude_settings(self, output_dir: Path) -> None:
@@ -805,7 +795,6 @@ class TestClaudeCodeConfig:
         assert "Bash(gh pr *)" in allow
         assert "Edit" in allow
         assert "Write" in allow
-        assert "mcp__context7__query-docs" in allow
         assert "mcp__playwright__browser_snapshot" in allow
         assert "Bash(git reset --hard *)" in deny
         assert "Bash(rm *)" in deny
@@ -826,7 +815,6 @@ class TestClaudeCodeConfig:
         content = (project / "CLAUDE.md").read_text()
         assert "## Agents IA" in content
         assert "contremaitre" in content.lower()
-        assert "context7" in content
         assert "playwright" in content
 
 

--- a/{{ cookiecutter.__project_name_kebab_case }}/.claude/settings.json
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.claude/settings.json
@@ -67,9 +67,7 @@
       "mcp__playwright__browser_press_key",
       "mcp__playwright__browser_wait_for",
       "mcp__playwright__browser_close",
-      "mcp__playwright__browser_install",
-      "mcp__context7__resolve-library-id",
-      "mcp__context7__query-docs"
+      "mcp__playwright__browser_install"
     ]
   },
   "enabledPlugins": {

--- a/{{ cookiecutter.__project_name_kebab_case }}/.claude/settings.local.json
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.claude/settings.local.json
@@ -1,5 +1,5 @@
 {
-  "enabledMcpjsonServers": [ "playwright"],
+  "enabledMcpjsonServers": ["playwright"],
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true,
     "code-review@claude-plugins-official": true

--- a/{{ cookiecutter.__project_name_kebab_case }}/.claude/settings.local.json
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.claude/settings.local.json
@@ -1,5 +1,5 @@
 {
-  "enabledMcpjsonServers": ["context7", "playwright"],
+  "enabledMcpjsonServers": [ "playwright"],
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true,
     "code-review@claude-plugins-official": true

--- a/{{ cookiecutter.__project_name_kebab_case }}/.mcp.json
+++ b/{{ cookiecutter.__project_name_kebab_case }}/.mcp.json
@@ -1,10 +1,5 @@
 {
   "mcpServers": {
-    "context7": {
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp"],
-      "env": {}
-    },
     "playwright": {
       "command": "npx",
       "args": ["-y", "@playwright/mcp@latest", "--browser", "chrome"],

--- a/{{ cookiecutter.__project_name_kebab_case }}/CLAUDE.md
+++ b/{{ cookiecutter.__project_name_kebab_case }}/CLAUDE.md
@@ -94,7 +94,6 @@ Le dossier `~/Claude/agents-dev/` contient les agents organisés par domaine. Le
 
 | Serveur | Usage |
 |---------|-------|
-| `context7` | Documentation technique à jour pour les librairies |
 | `playwright` | Automatisation navigateur, tests E2E, screenshots |
 
 Les serveurs org-spécifiques (atlassian, tempo, hubspot) s'ajoutent via le Contremaître.


### PR DESCRIPTION
voice (claude-voice-input) et context7 ne sont plus utilises. bigquery est retire au profit du connecteur BigQuery officiel de Google.

Les trois serveurs sont retires du registry central (Baseline-quebec/mcp-config#19) ; cette PR nettoie les configs MCP et les permissions de ce repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)